### PR TITLE
correct expire example date calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ new Vue({
     mounted: function() {
         Vue.ls.set('foo', 'boo');
         //Set expire for item
-        Vue.ls.set('foo', 'boo', 60 * 60 * 1000); //expiry 1 hour
+        Vue.ls.set('foo', 'boo', 60 * 60); //expiry 1 hour
         Vue.ls.get('foo');
         Vue.ls.get('boo', 10); //if not set boo returned default 10
         


### PR DESCRIPTION
according to 
https://github.com/RobinCK/vue-ls/blob/6f05098bdbc9b0cede4f23f6cfd5514a8dcd6edf/dist/vue-ls.js#L181

the expire should be in seconds in not in milli