### PR TITLE
Migrate to Vue 3

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,7 +59,7 @@ const VueStorage = {
     }, _options || {}));
 
     Vue[_options.name] = ls; // eslint-disable-line
-    Object.defineProperty(Vue.prototype, `$${_options.name}`, {
+    Object.defineProperty(Vue.prototype || Vue.config.globalProperties, `$${_options.name}`, {
       /**
        * Define $ls property
        *


### PR DESCRIPTION
Keeps backwards compatibility with Vue 2

* prototype is replaced in Vue 3  https://v3.vuejs.org/guide/migration/global-api.html#vue-prototype-replaced-by-config-globalproperties
