### PR TITLE
Handle security exception thrown when accessing store

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,17 +28,25 @@ const VueStorage = {
 
     switch(_options.storage) { // eslint-disable-line
       case 'local':
-        store = 'localStorage' in _global
-          ? _global.localStorage
-          : null
-        ;
+        try {
+          store = 'localStorage' in _global
+            ? _global.localStorage
+            : null
+          ;
+        } catch (e) {
+          // In some situations the browser will throw a security exception when attempting to access
+        }
         break;
 
       case 'session':
-        store = 'sessionStorage' in _global
-          ? _global.sessionStorage
-          : null
-        ;
+        try {
+          store = 'sessionStorage' in _global
+            ? _global.sessionStorage
+            : null
+          ;
+        } catch (e) {
+          // In some situations the browser will throw a security exception when attempting to access
+        }
         break;
       case 'memory':
         store = MemoryStorage;


### PR DESCRIPTION
In some situations a security exception will be thrown by the browser when trying to access `window.localStorage` or `window.sessionStorage`.

One situation is if your vue app is inside an iframe on a page viewed in incognito mode.
When this exception is thrown it prevents the entire vue app from booting.

Here is an example from the developer tools console in the context of the iframe.

<img width="859" alt="Screen Shot 2022-03-17 at 17 07 26" src="https://user-images.githubusercontent.com/1701266/158755205-7fa9839b-dd49-4617-b781-cf566b3655d8.png">

